### PR TITLE
Fix connection.connect fails if connection is existing but broken

### DIFF
--- a/maxcube/connection.py
+++ b/maxcube/connection.py
@@ -13,8 +13,11 @@ class MaxCubeConnection:
 
     def connect(self):
         logger.debug('Connecting to Max! Cube at ' + self.host + ':' + str(self.port))
-        if self.socket:
-            self.disconnect()
+        try:
+            if self.socket:
+                self.disconnect()
+        except:
+            logger.debug('Tried disconnecting from cube, caught Exception probably due to stale connection.')
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.socket.settimeout(2)


### PR DESCRIPTION
If the exception is not caught, when being used by homeassistant it errors out after a few hours.