### PR TITLE
Wall stat temp is actually 9 bits with the 9th bit being the topmost bit of byte 8

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -225,7 +225,7 @@ class MaxCube(MaxDevice):
 
             # Wall Thermostat
             if device and self.is_wallthermostat(device):
-                device.actual_temperature = data[pos + 12] / 10.0
+                device.actual_temperature = (((data[pos + 8] & 0x80) << 1) + data[pos + 12]) / 10.0
 
             # Window Shutter
             if device and self.is_windowshutter(device):


### PR DESCRIPTION
This broke if the temperature went over 256 (25.6c) - it reported a really low temperature. The docs were also wrong on this - they said it was the topmost bit of byte 7. I have pull requested a fix there too: https://github.com/Bouni/max-cube-protocol/pull/34
